### PR TITLE
Fixing bad routing

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func main() {
 
 	// Explicitly serve index.html at the root
 	r.StaticFile("/", "chat-ui/build/index.html")
+	// Serve not routing requests like get /create-user
+	r.NoRoute(func(c *gin.Context) {
+		c.File("ui/build/index.html")
+	})
 	// Serve static files under /static
 	r.StaticFS("/static", http.Dir("chat-ui/build/static"))
 


### PR DESCRIPTION
I have reproduced all three tutorial parts and found a problem while testing the final version.
When you open the Login page at the beginning and try to create a new user, it redirects to /create-user and fails with 404.
This is because the backend does not respond to endpoints not presented in the router.
NoRoute function Is the one that solves that problem.